### PR TITLE
Removing TAG as a part of speech tag.

### DIFF
--- a/metanl/english.py
+++ b/metanl/english.py
@@ -169,7 +169,7 @@ def tag_and_stem(text):
     tagged = nltk.pos_tag(tokens)
     out = []
     for token, tag in tagged:
-        if token.startswith('#'):
+        if token.startswith('#') or token.startswith('@'):
             stem = morphy_stem(token[1:], tag)
             out.append((stem, tag, token))
         elif token in BRACKET_DIC:

--- a/metanl/english.py
+++ b/metanl/english.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 import nltk
 from nltk.corpus import wordnet
-from metanl.general import (preprocess_text, tokenize, untokenize,
-        tokenize_list, untokenize_list, un_camel_case)
+from metanl.general import preprocess_text, tokenize_list, untokenize_list
 from metanl.wordlist import Wordlist
 import re
 
@@ -171,7 +170,8 @@ def tag_and_stem(text):
     out = []
     for token, tag in tagged:
         if token.startswith('#'):
-            out.append((token, 'TAG', token))
+            stem = morphy_stem(token[1:], tag)
+            out.append((stem, tag, token))
         elif token in BRACKET_DIC:
             out.append((token, BRACKET_DIC[token], token))
         else:

--- a/metanl/extprocess.py
+++ b/metanl/extprocess.py
@@ -182,6 +182,11 @@ class ProcessWrapper(object):
         appropriate for the reader. `pos` can be as general or specific as
         necessary (for example, it might label all parts of speech, or it might
         only distinguish function words from others).
+
+        Twitter-style hashtags and at-mentions have the stem and pos they would
+        have without the leading # or @. For instance, if the reader's triple
+        for "thing" is ('thing', 'NN', 'things'), then "#things" would come out
+        as ('thing', 'NN', '#things').
         """
         analysis = self.analyze(text)
         triples = []
@@ -193,8 +198,8 @@ class ProcessWrapper(object):
 
             if token:
                 if tag_next:
-                    triples.append((tag_next + token, 'TAG',
-                                    tag_next + token))
+                    pos = self.get_record_pos(record)
+                    triples.append((token, pos, tag_next + token))
                     tag_next = False
                 elif token == u'#' or token == u'@':
                     tag_next = token


### PR DESCRIPTION
Both metanl.english and ProcessWrapper in metanl.extprocess, instead of
treating "#word" and "@word" as special unstemmed tokens with the part of
speech "TAG", will now give them the stems and parts of speech they would have
had without the leading # or @.

Also removing some unused imports from metanl.english, while I was in there.
